### PR TITLE
avoid assign nil to authenticateHandler

### DIFF
--- a/Sources/bevy_ios_gamecenter/BevyIosGamecenter.swift
+++ b/Sources/bevy_ios_gamecenter/BevyIosGamecenter.swift
@@ -37,7 +37,6 @@ public func authenticate(request: Int64) {
             return
         }
         
-        GKLocalPlayer.local.authenticateHandler = nil
         GKLocalPlayer.local.authenticateHandler = { gcAuthVC, error in
             if GKLocalPlayer.local.isAuthenticated {
                 receive_authentication(request, IosGCAuthResult.authenticated())


### PR DESCRIPTION
This can causing `The authenticateHandler must not be nil` exception and crash the app, by remove the unnecessary nil assignment the exception gone.